### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/main/main.py
+++ b/main/main.py
@@ -1,5 +1,4 @@
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import process, fuzz
 import argparse
 from engine.tokenizer import Tokenizer
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-fuzzywuzzy==0.18.0
-python-Levenshtein==0.12.0
+rapidfuzz==0.9.1


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy